### PR TITLE
Humans now sent to jail (Issue #21)

### DIFF
--- a/monopoly.js
+++ b/monopoly.js
@@ -2390,7 +2390,7 @@ function land(increasedRent) {
 		updatePosition();
 
 		if (p.human) {
-			popup("<div>Go to jail. Go directly to Jail. Do not pass GO. Do not collect $200.</div>", goToJail);
+			popup("<div>Go to jail. Go directly to Jail. Do not pass GO. Do not collect $200.</div>", gotojail);
 		} else {
 			gotojail();
 		}


### PR DESCRIPTION
Resolves issue #21  where human players aren't sent to jail when they land on the Go To Jail board location.

The issue was a case mismatch resulting in an undefined function being called.